### PR TITLE
Use daily color for tag pills on post pages

### DIFF
--- a/assets/scss/pages/post.scss
+++ b/assets/scss/pages/post.scss
@@ -126,12 +126,12 @@ $tocBreakpoint: 1024px;
   text-decoration: none;
   padding: 0.2em 0.4em;
   border-radius: 3px;
-  background: lighten($primary, 41%);
-  color: $primary;
+  background: color-mix(in srgb, var(--daily-color, #{$primary}) 12%, white);
+  color: var(--daily-color, #{$primary});
   font-size: 0.8rem;
 
   &:hover {
-    background: lighten($primary, 38%);
+    background: color-mix(in srgb, var(--daily-color, #{$primary}) 22%, white);
   }
 }
 


### PR DESCRIPTION
## Summary
- Tag pills on individual post pages now use `var(--daily-color)` instead of the static `$primary` color
- Background is a 12% tint of the daily color (22% on hover), matching the existing style in `tags.scss`
- The daily color is already set by the JS in `index.js` and applied on the tags list page — this makes post pages consistent

## Test plan
- [ ] Visit a blog post and confirm the tag pills change color each day
- [ ] Confirm hover state works correctly
- [ ] Confirm fallback to `$primary` purple when JS hasn't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)